### PR TITLE
adding interface files and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,9 @@ def config_changed():
     if reactive.is_flag_set('bind-stats.connected'):
         config = hookenv.config()
         if config.changed("stats-port"):
-            shared_data = {
-                'stats-port': hookenv.config('stats-port'),
-                'stats-ip': '127.0.0.1'
-            }
-            bind_stats_endpoint.configure(shared_data)
+            bind_stats_endpoint.configure(
+                ip='127.0.0.1', port=hookenv.config('stats-port')
+            )
 
     designate_bind.set_apparmor()
     designate_bind.render_all_configs(

--- a/README.md
+++ b/README.md
@@ -4,14 +4,76 @@ This interface supports integration between designate-bind and prometheus-bind-e
 
 # Usage
 
-## metadata
+## Layer
 To consume this interface in your charm or layer, add the following to `layer.yaml`:
 
 ```yaml
 includes: ['interface:bind-client']
 ```
 
-and add a requires interface of type `bind-client` to your charm or layers
+## Provides
+
+Add a provides interface of type `bind-client` to your charm or layers
+`metadata.yaml`:
+
+```yaml
+provides:
+  dns-backend:
+    interface: bind-rndc
+  bind-stats:
+    interface: bind-client
+```
+
+* Note that `charm-designate-bind` normally works with `charm-designate` with the `bind-rndc` interface.
+
+### flag: {relation_name}.connected
+
+This flag is set when the `bind-exporter` unit is joined and removes when departed, or broken.
+
+For example, the following code is used in [charm-designate-bind](https://opendev.org/openstack/charm-designate-bind) and the charm may not use a `bind-exporter`. When the `bind-exporter` is not present, the flag `{relation_name}.connected` won't be set and the templates will react accordingly with this.
+
+When the flag `{relation_name}.connected` is set, it will create a new file `/etc/bind/stats.conf` in charm-designate-bind with the following content:
+```
+statistics-channels {
+  inet <stats-listen-net> port <stats-port> allow { <client-ip>; };
+};
+```
+It will also include this new file at `etc/bind/named.conf`. This will open a statistics channel in bind that `bind-exporter`
+can expose metrics to collect.
+
+When the flag is not set, the statistics channel is closed.
+
+If the `bind-exporter` is present in the bundle, it will check if configuration has changed and send this information through the endpoint of the relation.
+
+```python
+import charm.openstack.designate_bind as designate_bind
+
+@reactive.when('rndckey.available')
+@reactive.when('dns-backend.related')
+def config_changed():
+    '''Render configs and restart services if necessary.'''
+
+    dns_backend_endpoint = reactive.endpoint_from_flag("dns-backend.related")
+    bind_stats_endpoint = reactive.endpoint_from_name("bind-stats")
+
+    if reactive.is_flag_set('bind-stats.connected'):
+        config = hookenv.config()
+        if config.changed("stats-port"):
+            shared_data = {
+                'stats-port': hookenv.config('stats-port'),
+                'stats-ip': '127.0.0.1'
+            }
+            bind_stats_endpoint.configure(shared_data)
+
+    designate_bind.set_apparmor()
+    designate_bind.render_all_configs(
+        [dns_backend_endpoint, bind_stats_endpoint]
+    )
+```
+
+## Requires
+
+Add a requires interface of type `bind-client` to your charm or layers
 `metadata.yaml`:
 
 ```yaml
@@ -20,37 +82,14 @@ requires:
     interface: bind-client
 ```
 
-## flag: {relation_name}.connected
-
-This flag is set when the subordinate unit is joined and removes when departed.
-
-For example, the following code will update the relation just when the relation is estabilished and the configuration changed:
+### flag: {relation_name}.connected
+This flag is set when the `bind-exporter` unit is joined and removes when departed, or broken.
 
 ```python
-@reactive.when('rndckey.available')
-@reactive.when('dns-backend.related')
-def config_changed():
-    '''Render configs and restart services if necessary'''
-    endpoints = [
-        reactive.endpoint_from_flag('dns-backend.related'),
-        reactive.endpoint_from_name('bind-stats')
-    ]
+@reactive.when('bind-stats.connected')
+def start_bind_exporter():
 
-    if reactive.is_flag_set('bind-stats.connected'):
-        config = hookenv.config()
-        if config.changed("stats-port"):
-            endpoints[1].configure(hookenv.config('stats-port'))
-
-    designate_bind.set_apparmor()
-    designate_bind.render_all_configs(endpoints)
+    bind_stats_endpoint = reactive.endpoint_from_flag("bind-stats")
+    config = bind_stats_endpoint.get_config()
+    # logic to start the bind exporter
 ```
-When this flag is set, it will create a new file `/etc/bind/stats.conf` in charm-designate-bind with the following content:
-```
-statistics-channels {
-  inet <stats-listen-net> port <stats-port> allow { <client-ip>; };
-};
-```
-It will also include this new file at `etc/bind/named.conf`. This will open a statistics channel in bind that prometheus-bind-exporter
-can expose metrics for prometheus to collect.
-
-When the flag is not set, the statistics channel is closed.

--- a/README.md
+++ b/README.md
@@ -27,17 +27,22 @@ This flag is set when the subordinate unit is joined and removes when departed.
 For example, the following code will update the relation just when the relation is estabilished and the configuration changed:
 
 ```python
-if reactive.is_flag_set('bind-stats.connected'):
+@reactive.when('rndckey.available')
+@reactive.when('dns-backend.related')
+def config_changed():
+    '''Render configs and restart services if necessary'''
+    endpoints = [
+        reactive.endpoint_from_flag('dns-backend.related'),
+        reactive.endpoint_from_name('bind-stats')
+    ]
+
+    if reactive.is_flag_set('bind-stats.connected'):
         config = hookenv.config()
         if config.changed("stats-port"):
-            relation_settings = {
-                'stats-port': hookenv.config('stats-port')
-            }
-            for rel_id in hookenv.relation_ids('bind-stats'):
-                hookenv.relation_set(
-                    rel_id,
-                    relation_settings=relation_settings
-                )
+            endpoints[1].configure(hookenv.config('stats-port'))
+
+    designate_bind.set_apparmor()
+    designate_bind.render_all_configs(endpoints)
 ```
 When this flag is set, it will create a new file `/etc/bind/stats.conf` in charm-designate-bind with the following content:
 ```

--- a/README.md
+++ b/README.md
@@ -20,18 +20,17 @@ requires:
     interface: bind-client
 ```
 
-## flag: {relation_name}.available
+## flag: {relation_name}.connected
 
 This flag is set when the subordinate unit is joined and removes when departed.
 
 For example, the following code will update the relation just when the relation is estabilished and the configuration changed:
 
 ```python
-if reactive.is_flag_set('bind-stats.available'):
+if reactive.is_flag_set('bind-stats.connected'):
         config = hookenv.config()
-        if config.changed("stats-port") or config.changed("stats-listen-net"):
+        if config.changed("stats-port"):
             relation_settings = {
-                'stats-listen-net': hookenv.config('stats-listen-net'),
                 'stats-port': hookenv.config('stats-port')
             }
             for rel_id in hookenv.relation_ids('bind-stats'):

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,0 +1,12 @@
+name: bind-client
+summary: Interface for intergrating bind
+maintainer: DevOps Centres
+ignore:
+  - 'unit_tests'
+  - '.stestr.conf'
+  - 'test-requirements.txt'
+  - 'tox.ini'
+  - '.gitignore'
+  - '.travis.yml'
+  - '.zuul.yaml'
+  - '.tox'

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,6 +1,6 @@
 name: bind-client
 summary: Interface for intergrating bind
-maintainer: DevOps Centres
+maintainer: Gabriel Cocenza <gabriel.cocenza@canonical.com>
 ignore:
   - unit_tests
   - .stestr.conf

--- a/interface.yaml
+++ b/interface.yaml
@@ -2,11 +2,11 @@ name: bind-client
 summary: Interface for intergrating bind
 maintainer: DevOps Centres
 ignore:
-  - 'unit_tests'
-  - '.stestr.conf'
-  - 'test-requirements.txt'
-  - 'tox.ini'
-  - '.gitignore'
-  - '.travis.yml'
-  - '.zuul.yaml'
-  - '.tox'
+  - unit_tests
+  - .stestr.conf
+  - test-requirements.txt
+  - tox.ini
+  - .gitignore
+  - .travis.yml
+  - .zuul.yaml
+  - .tox

--- a/provides.py
+++ b/provides.py
@@ -28,9 +28,6 @@ class BindClientProvides(reactive.Endpoint):
     def joined(self):
         reactive.set_flag(self.expand_name("{endpoint_name}.connected"))
 
-    # NOTE(gabrielcocenza): The framework doesn't pass arguments to the
-    # handler using the decorator @when_any. That is why the methods
-    # departed and broken are repetitive.
     @reactive.when("endpoint.{endpoint_name}.departed")
     def departed(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
@@ -38,12 +35,14 @@ class BindClientProvides(reactive.Endpoint):
     @reactive.when("endpoint.{endpoint_name}.broken")
     def broken(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
+        self.configure({'stats-port': None, 'stats-ip': None})
 
-    def configure(self, port):
-        """Configure the port to be used in the relation between units
+    def configure(self, shared_data):
+        """Configure the data shared between the two units using the interface.
 
-        :param port: port to listen
-        :type port: str
+        :param shared_data: Dict containing the key:values to be shared
+        :type shared_data: Dict
         """
         for relation in self.relations:
-            relation.to_publish_raw['port'] = port
+            for key, value in shared_data.items():
+                relation.to_publish_raw[key] = value

--- a/provides.py
+++ b/provides.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from charms import reactive
+import charmhelpers.contrib.network.ip as ch_net_ip
+
+
+class BindClientProvides(reactive.Endpoint):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ingress_address = ch_net_ip.get_relation_ip(self.endpoint_name)
+
+    def relation_ids(self):
+        return [relation.relation_id for relation in self.relations]
+
+    def set_ingress_address(self):
+        for relation in self.relations:
+            relation.to_publish_raw["ingress-address"] = self.ingress_address
+            relation.to_publish_raw["private-address"] = self.ingress_address
+
+    def available(self):
+        return reactive.is_flag_set(
+            self.expand_name("{endpoint_name}.available")
+        )
+
+    @reactive.when("endpoint.{endpoint_name}.joined")
+    def joined(self):
+        if not self.available():
+            reactive.set_flag(self.expand_name("{endpoint_name}.available"))
+            self.set_ingress_address()
+
+    def remove(self):
+        if self.available():
+            reactive.clear_flag(self.expand_name("{endpoint_name}.available"))
+
+    @reactive.when("endpoint.{endpoint_name}.broken")
+    def broken(self):
+        self.remove()
+
+    @reactive.when("endpoint.{endpoint_name}.departed")
+    def departed(self):
+        self.remove()

--- a/provides.py
+++ b/provides.py
@@ -13,41 +13,20 @@
 # limitations under the License.
 
 from charms import reactive
-import charmhelpers.contrib.network.ip as ch_net_ip
 
 
 class BindClientProvides(reactive.Endpoint):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.ingress_address = ch_net_ip.get_relation_ip(self.endpoint_name)
-
-    def relation_ids(self):
-        return [relation.relation_id for relation in self.relations]
-
-    def set_ingress_address(self):
-        for relation in self.relations:
-            relation.to_publish_raw["ingress-address"] = self.ingress_address
-            relation.to_publish_raw["private-address"] = self.ingress_address
-
-    def available(self):
-        return reactive.is_flag_set(
-            self.expand_name("{endpoint_name}.available")
-        )
 
     @reactive.when("endpoint.{endpoint_name}.joined")
     def joined(self):
-        if not self.available():
-            reactive.set_flag(self.expand_name("{endpoint_name}.available"))
-            self.set_ingress_address()
-
-    def remove(self):
-        if self.available():
-            reactive.clear_flag(self.expand_name("{endpoint_name}.available"))
-
-    @reactive.when("endpoint.{endpoint_name}.broken")
-    def broken(self):
-        self.remove()
+        reactive.set_flag(self.expand_name("{endpoint_name}.connected"))
 
     @reactive.when("endpoint.{endpoint_name}.departed")
     def departed(self):
-        self.remove()
+        reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @reactive.when("endpoint.{endpoint_name}.broken")
+    def broken(self):
+        reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))

--- a/provides.py
+++ b/provides.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE(gabrielcocenza): The files provides.py and requires.py
+# are basically using the same code for the handlers. Currently,
+# the reactive framework is not able to recognise handlers from
+# a parent class that child classes could inherit.
+
 from charms import reactive
 
 
@@ -23,6 +28,9 @@ class BindClientProvides(reactive.Endpoint):
     def joined(self):
         reactive.set_flag(self.expand_name("{endpoint_name}.connected"))
 
+    # NOTE(gabrielcocenza): The framework doesn't pass arguments to the
+    # handler using the decorator @when_any. That is why the methods
+    # departed and broken are repetitive.
     @reactive.when("endpoint.{endpoint_name}.departed")
     def departed(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
@@ -30,3 +38,12 @@ class BindClientProvides(reactive.Endpoint):
     @reactive.when("endpoint.{endpoint_name}.broken")
     def broken(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
+
+    def configure(self, port):
+        """Configure the port to be used in the relation between units
+
+        :param port: port to listen
+        :type port: str
+        """
+        for relation in self.relations:
+            relation.to_publish_raw['port'] = port

--- a/requires.py
+++ b/requires.py
@@ -12,17 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE(gabrielcocenza): The files provides.py and requires.py
+# are basically using the same code for the handlers. Currently,
+# the reactive framework is not able to recognise handlers from
+# a parent class that child classes could inherit.
+
 from charms import reactive
 
 
 class BindClientRequires(reactive.Endpoint):
 
-    scope = reactive.scopes.GLOBAL
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @reactive.when('endpoint.{endpoint_name}.joined')
     def joined(self):
         reactive.set_flag(self.expand_name('{endpoint_name}.connected'))
 
+    # NOTE(gabrielcocenza): The framework doesn't pass arguments to the
+    # handler using the decorator @when_any. That is why the methods
+    # departed and broken are repetitive.
     @reactive.when("endpoint.{endpoint_name}.departed")
     def departed(self):
         reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))

--- a/requires.py
+++ b/requires.py
@@ -21,15 +21,12 @@ class BindClientRequires(reactive.Endpoint):
 
     @reactive.when('endpoint.{endpoint_name}.joined')
     def joined(self):
-        reactive.set_flag(self.expand_name('{endpoint_name}.available'))
+        reactive.set_flag(self.expand_name('{endpoint_name}.connected'))
 
-    def remove(self):
-        reactive.clear_flag(self.expand_name('{endpoint_name}.available'))
-
-    @reactive.when('endpoint.{endpoint_name}.broken')
-    def broken(self):
-        self.remove()
-
-    @reactive.when('endpoint.{endpoint_name}.departed')
+    @reactive.when("endpoint.{endpoint_name}.departed")
     def departed(self):
-        self.remove()
+        reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))
+
+    @reactive.when("endpoint.{endpoint_name}.broken")
+    def broken(self):
+        reactive.clear_flag(self.expand_name("{endpoint_name}.connected"))

--- a/requires.py
+++ b/requires.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from charms import reactive
+
+
+class BindClientRequires(reactive.Endpoint):
+
+    scope = reactive.scopes.GLOBAL
+
+    @reactive.when('endpoint.{endpoint_name}.joined')
+    def joined(self):
+        reactive.set_flag(self.expand_name('{endpoint_name}.available'))
+
+    def remove(self):
+        reactive.clear_flag(self.expand_name('{endpoint_name}.available'))
+
+    @reactive.when('endpoint.{endpoint_name}.broken')
+    def broken(self):
+        self.remove()
+
+    @reactive.when('endpoint.{endpoint_name}.departed')
+    def departed(self):
+        self.remove()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 charms.reactive
 flake8>=2.2.4
+# NOTE(gabrielcocenza): Mock is a dependence of the module
+# test_utils in charms_openstack.
 mock>=1.2
 stestr>=2.2.0
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mock out charmhelpers so that we can test without it.
+import charms_openstack.test_mocks  # noqa
+charms_openstack.test_mocks.mock_charmhelpers()

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -76,11 +76,20 @@ class TestBindClientProvides(test_utils.PatchHelper):
 
     def test_broken(self):
         self.ep.broken()
+        _calls = [
+            mock.call("stats-port", None),
+            mock.call("stats-ip", None),
+        ]
         self.clear_flag.assert_called_once_with(
             "{}.connected".format(self.ep_name)
         )
+        self.fake_relation.to_publish_raw.__setitem__.assert_has_calls(_calls)
 
     def test_configure(self):
-        self.ep.configure('1234')
-        _calls = [mock.call("port", '1234')]
+        shared_data = {'stats-port': '1234', 'stats-ip': '10.152.183.98'}
+        self.ep.configure(shared_data)
+        _calls = [
+            mock.call("stats-port", '1234'),
+            mock.call("stats-ip", '10.152.183.98'),
+        ]
         self.fake_relation.to_publish_raw.__setitem__.assert_has_calls(_calls)

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -1,0 +1,104 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import charms_openstack.test_utils as test_utils
+import mock
+import provides
+
+
+class TestRegisteredHooks(test_utils.TestRegisteredHooks):
+
+    def test_hooks(self):
+        defaults = []
+        hook_set = {
+            "when": {
+                "joined": ("endpoint.{endpoint_name}.joined",),
+                "departed": ("endpoint.{endpoint_name}.departed",),
+                "broken": ("endpoint.{endpoint_name}.broken",),
+            },
+        }
+        # test that the hooks were registered
+        self.registered_hooks_test_helper(provides, hook_set, defaults)
+
+
+class TestBindClientProvides(test_utils.PatchHelper):
+
+    def setUp(self):
+        super().setUp()
+        self._patches = {}
+        self._patches_start = {}
+        self.patch_object(provides.reactive, "clear_flag")
+        self.patch_object(provides.reactive, "set_flag")
+        self.patch_object(provides.reactive, "is_flag_set")
+
+        self.fake_unit = mock.MagicMock()
+        self.fake_unit.unit_name = "designate-bind/0"
+
+        self.fake_relation_id = "bind-client:3"
+        self.fake_relation = mock.MagicMock()
+        self.fake_relation.relation_id = self.fake_relation_id
+        self.fake_relation.units = [self.fake_unit]
+
+        self.ep_name = "bind-client"
+        self.ep = provides.BindClientProvides(
+            self.ep_name, [self.fake_relation_id])
+        self.ep.relations[0] = self.fake_relation
+
+    def tearDown(self):
+        self.ep = None
+        for k, v in self._patches.items():
+            v.stop()
+            setattr(self, k, None)
+        self._patches = None
+        self._patches_start = None
+
+    def test_joined_not_available(self):
+        self.ep.set_ingress_address = mock.MagicMock()
+        self.is_flag_set.return_value = False
+        self.ep.joined()
+        self.set_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )
+        self.ep.set_ingress_address.assert_called_once()
+
+    def test_joined_available(self):
+        self.ep.set_ingress_address = mock.MagicMock()
+        self.is_flag_set.return_value = True
+        self.ep.joined()
+        self.set_flag.assert_not_called()
+        self.ep.set_ingress_address.assert_not_called()
+
+    def test_departed_available(self):
+        self.is_flag_set.return_value = True
+        self.ep.departed()
+        self.clear_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )
+
+    def test_departed_not_available(self):
+        self.is_flag_set.return_value = False
+        self.ep.departed()
+        self.clear_flag.assert_not_called()
+
+    def test_broken_available(self):
+        self.is_flag_set.return_value = True
+        self.ep.broken()
+        self.clear_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )
+
+    def test_broken_not_available(self):
+        self.is_flag_set.return_value = False
+        self.ep.broken()
+        self.clear_flag.assert_not_called()

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -40,7 +40,6 @@ class TestBindClientProvides(test_utils.PatchHelper):
         self._patches_start = {}
         self.patch_object(provides.reactive, "clear_flag")
         self.patch_object(provides.reactive, "set_flag")
-        self.patch_object(provides.reactive, "is_flag_set")
 
         self.fake_unit = mock.MagicMock()
         self.fake_unit.unit_name = "designate-bind/0"
@@ -63,42 +62,20 @@ class TestBindClientProvides(test_utils.PatchHelper):
         self._patches = None
         self._patches_start = None
 
-    def test_joined_not_available(self):
-        self.ep.set_ingress_address = mock.MagicMock()
-        self.is_flag_set.return_value = False
+    def test_joined(self):
         self.ep.joined()
         self.set_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )
-        self.ep.set_ingress_address.assert_called_once()
 
-    def test_joined_available(self):
-        self.ep.set_ingress_address = mock.MagicMock()
-        self.is_flag_set.return_value = True
-        self.ep.joined()
-        self.set_flag.assert_not_called()
-        self.ep.set_ingress_address.assert_not_called()
-
-    def test_departed_available(self):
-        self.is_flag_set.return_value = True
+    def test_departed(self):
         self.ep.departed()
         self.clear_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )
 
-    def test_departed_not_available(self):
-        self.is_flag_set.return_value = False
-        self.ep.departed()
-        self.clear_flag.assert_not_called()
-
-    def test_broken_available(self):
-        self.is_flag_set.return_value = True
+    def test_broken(self):
         self.ep.broken()
         self.clear_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )
-
-    def test_broken_not_available(self):
-        self.is_flag_set.return_value = False
-        self.ep.broken()
-        self.clear_flag.assert_not_called()

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -79,3 +79,8 @@ class TestBindClientProvides(test_utils.PatchHelper):
         self.clear_flag.assert_called_once_with(
             "{}.connected".format(self.ep_name)
         )
+
+    def test_configure(self):
+        self.ep.configure('1234')
+        _calls = [mock.call("port", '1234')]
+        self.fake_relation.to_publish_raw.__setitem__.assert_has_calls(_calls)

--- a/unit_tests/test_requires.py
+++ b/unit_tests/test_requires.py
@@ -1,0 +1,81 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import charms_openstack.test_utils as test_utils
+import mock
+import requires
+
+
+class TestRegisteredHooks(test_utils.TestRegisteredHooks):
+
+    def test_hooks(self):
+        defaults = []
+        hook_set = {
+            "when": {
+                "joined": ("endpoint.{endpoint_name}.joined",),
+                "departed": ("endpoint.{endpoint_name}.departed",),
+                "broken": ("endpoint.{endpoint_name}.broken",),
+            },
+        }
+        # test that the hooks were registered
+        self.registered_hooks_test_helper(requires, hook_set, defaults)
+
+
+class TestBindClientRequires(test_utils.PatchHelper):
+    def setUp(self):
+        super().setUp()
+        self._patches = {}
+        self._patches_start = {}
+        self.patch_object(requires.reactive, "clear_flag")
+        self.patch_object(requires.reactive, "set_flag")
+
+        self.fake_unit = mock.MagicMock()
+        self.fake_unit.unit_name = "my-unit/0"
+
+        self.fake_relation_id = "bind-client:3"
+        self.fake_relation = mock.MagicMock()
+        self.fake_relation.relation_id = self.fake_relation_id
+        self.fake_relation.units = [self.fake_unit]
+
+        self.ep_name = "bind-client"
+        self.ep = requires.BindClientRequires(
+            self.ep_name, [self.fake_relation_id]
+        )
+        self.ep.relations[0] = self.fake_relation
+
+    def tearDown(self):
+        self.ep = None
+        for k, v in self._patches.items():
+            v.stop()
+            setattr(self, k, None)
+        self._patches = None
+        self._patches_start = None
+
+    def test_joined(self):
+        self.ep.joined()
+        self.set_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )
+
+    def test_departed(self):
+        self.ep.departed()
+        self.clear_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )
+
+    def test_broken(self):
+        self.ep.broken()
+        self.clear_flag.assert_called_once_with(
+            "{}.available".format(self.ep_name)
+        )

--- a/unit_tests/test_requires.py
+++ b/unit_tests/test_requires.py
@@ -65,17 +65,17 @@ class TestBindClientRequires(test_utils.PatchHelper):
     def test_joined(self):
         self.ep.joined()
         self.set_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )
 
     def test_departed(self):
         self.ep.departed()
         self.clear_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )
 
     def test_broken(self):
         self.ep.broken()
         self.clear_flag.assert_called_once_with(
-            "{}.available".format(self.ep_name)
+            "{}.connected".format(self.ep_name)
         )

--- a/unit_tests/test_requires.py
+++ b/unit_tests/test_requires.py
@@ -46,7 +46,7 @@ class TestBindClientRequires(test_utils.PatchHelper):
         self.fake_relation_id = "bind-client:3"
         self.fake_relation = mock.MagicMock()
         self.fake_relation.relation_id = self.fake_relation_id
-        self.fake_relation.units = [self.fake_unit]
+        self.fake_relation.joined_units = [self.fake_unit]
 
         self.ep_name = "bind-client"
         self.ep = requires.BindClientRequires(
@@ -79,3 +79,26 @@ class TestBindClientRequires(test_utils.PatchHelper):
         self.clear_flag.assert_called_once_with(
             "{}.connected".format(self.ep_name)
         )
+
+    def test_config_default(self):
+        self.fake_unit.received_raw = {}
+        config = self.ep.get_config()
+        expected_config = {
+            self.fake_unit.unit_name: {
+                "stats-port": "8053",
+                "stats-ip": "127.0.0.1",
+            }
+        }
+
+        self.assertEqual(config, expected_config)
+
+    def test_config_changed(self):
+        self.fake_unit.received_raw = {
+            "stats-port": "1234",
+            "stats-ip": "10.152.183.50",
+        }
+        config = self.ep.get_config()
+        expected_config = {
+            self.fake_unit.unit_name: self.fake_unit.received_raw
+        }
+        self.assertEqual(config, expected_config)


### PR DESCRIPTION
This PR attempts to add a new interface that will support the integration between designate-bind and prometheus-bind-exporter-operator.

After the approval, I will open a PR in [juju layer-index](https://github.com/juju/layer-index) in order to be able to fetch directly when building the `charm-designate-bind`

Closes-Bug: [#1938888](https://bugs.launchpad.net/charm-designate-bind/+bug/1938888)
[Gerrit-PR](https://github.com/canonical/interface-bind-client/compare/master...gabrielcocenza:bug/1938888?expand=1) 